### PR TITLE
Ensure datapackage<1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     author = 'Eric Schles',
     author_email = 'ericschles@gmail.com',
     install_requires = [
-        'datapackage',
+        'datapackage<1.0',
         'argparse',
         'distribute',
         'statsmodels',


### PR DESCRIPTION
Hi! Frictionless Data's `datapackage-py` is going to reach v1 release and it could be breaking for some software (we use SemVer). Adding `<1.0` version requirement.